### PR TITLE
Bumping version to generate a new release tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3851,7 +3851,7 @@ checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "sns-quill"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sns-quill"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["DFINITY Team"]
 edition = "2018"
 


### PR DESCRIPTION
Since sns-quill was forked and mirrored from quill, there are already release tags spanning v0.2.0 to v0.2.14. I wanted to maintain those releases as they are part of the commit history, but also wanted to generate a release for new sns-quill tool that diverges from quill