### PR TITLE
Add dapp canisters to canister.json

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,8 @@ use bip39::Mnemonic;
 use clap::{crate_version, Parser};
 use ic_base_types::CanisterId;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fs::File, path::PathBuf, str::FromStr};
 use serde_json::Value;
+use std::{collections::HashMap, fs::File, path::PathBuf, str::FromStr};
 
 mod commands;
 mod lib;
@@ -119,7 +119,7 @@ fn read_sns_canister_ids(file_path: Option<String>) -> AnyhowResult<Option<SnsCa
         Err(err) => {
             eprintln!("{}", err);
             vec![]
-        },
+        }
     };
 
     Ok(Some(SnsCanisterIds {
@@ -160,19 +160,23 @@ fn parse_dapp_canister_id_list(
         Value::Array(id_array) => {
             for id in id_array {
                 if let Value::String(str) = id {
-                    let canister_id = CanisterId::from_str(str)
-                        .map_err(|err| anyhow!("Could not parse {} as a CanisterId: {}", str, err))?;
+                    let canister_id = CanisterId::from_str(str).map_err(|err| {
+                        anyhow!("Could not parse {} as a CanisterId: {}", str, err)
+                    })?;
                     canister_id_vec.push(canister_id);
                 }
             }
             Ok(canister_id_vec)
-        },
+        }
         Value::String(str) => {
             let canister_id = CanisterId::from_str(str)
                 .map_err(|err| anyhow!("Could not parse {} as a CanisterId: {}", str, err))?;
             Ok(vec![canister_id])
         }
-        _ => Err(anyhow!("Failed to parse field {} as either a String or an Array", key_name)),
+        _ => Err(anyhow!(
+            "Failed to parse field {} as either a String or an Array",
+            key_name
+        )),
     }
 }
 
@@ -262,6 +266,7 @@ fn test_read_canister_ids_from_file() {
         governance_canister_id: CanisterId::from_str("rrkah-fqaaa-aaaaa-aaaaq-cai").unwrap(),
         ledger_canister_id: CanisterId::from_str("ryjl3-tyaaa-aaaaa-aaaba-cai").unwrap(),
         root_canister_id: CanisterId::from_str("r7inp-6aaaa-aaaaa-aaabq-cai").unwrap(),
+        dapp_canister_id_list: vec![],
     };
 
     let json_str = serde_json::to_string(&expected_canister_ids).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,10 +134,12 @@ fn parse_canister_id(
     key_name: &str,
     canister_id_map: &HashMap<String, Value>,
 ) -> AnyhowResult<CanisterId> {
-    let value = canister_id_map.get(key_name).ok_or(anyhow!(
-        "'{}' is not present in --canister-ids-file <file>",
-        key_name
-    ))?;
+    let value = canister_id_map.get(key_name).ok_or_else(|| {
+        anyhow!(
+            "'{}' is not present in --canister-ids-file <file>",
+            key_name
+        )
+    })?;
     if let Value::String(str) = value {
         let canister_id = CanisterId::from_str(str)
             .map_err(|err| anyhow!("Could not parse CanisterId of '{}': {}", key_name, err))?;
@@ -151,10 +153,12 @@ fn parse_dapp_canister_id_list(
     key_name: &str,
     canister_id_map: &HashMap<String, Value>,
 ) -> AnyhowResult<Vec<CanisterId>> {
-    let value = canister_id_map.get(key_name).ok_or(anyhow!(
-        "'{}' is not present in --canister-ids-file <file>",
-        key_name
-    ))?;
+    let value = canister_id_map.get(key_name).ok_or_else(|| {
+        anyhow!(
+            "'{}' is not present in --canister-ids-file <file>",
+            key_name
+        )
+    })?;
     let mut canister_id_vec: Vec<CanisterId> = vec![];
     match value {
         Value::Array(id_array) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,10 +170,7 @@ fn parse_dapp_canister_id_list(
             }
             Ok(canister_id_vec)
         }
-        _ => Err(anyhow!(
-            "Failed to parse field {} as an Array",
-            key_name
-        )),
+        _ => Err(anyhow!("Failed to parse field {} as an Array", key_name)),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,7 +169,7 @@ fn parse_dapp_canister_id_list(
             Ok(canister_id_vec)
         }
         _ => Err(anyhow!(
-            "Failed to parse field {} as either a String or an Array",
+            "Failed to parse field {} as an Array",
             key_name
         )),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,9 @@ pub struct CliOpts {
     ///   "governance_canister_id": "rrkah-fqaaa-aaaaa-aaaaq-cai",
     ///   "ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
     ///   "root_canister_id": "r7inp-6aaaa-aaaaa-aaabq-cai"
-    ///   "dapp_canister_id_list": [],
+    ///   "dapp_canister_id_list": [
+    ///.      "qoctq-giaaa-aaaaa-aaaea-cai"
+    ///.   ],
     /// }
     #[clap(long)]
     canister_ids_file: Option<String>,

--- a/tests/canister_ids.json
+++ b/tests/canister_ids.json
@@ -1,5 +1,6 @@
 {
   "governance_canister_id": "rrkah-fqaaa-aaaaa-aaaaq-cai",
   "ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
-  "root_canister_id": "r7inp-6aaaa-aaaaa-aaabq-cai"
+  "root_canister_id": "r7inp-6aaaa-aaaaa-aaabq-cai",
+  "dapp_canister_id_list": []
 }


### PR DESCRIPTION
This mr adds a field "dapp_canister_id_list" to the sns_canister struct. If the sns_canisters.json file has a field "dapp_canister_id_list" (that can be either an array or a single string) it will be added to the sns_canister struct. If the field is missing from the json file the code will not fail, so previous json files will continue to work.