### PR TITLE
feat: Add neuron-permission command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "base64 0.13.0",
  "build-info",
@@ -897,7 +897,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "candid",
  "dfn_core",
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -930,7 +930,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -942,7 +942,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "dfn_core",
  "ic-base-types",
@@ -1112,7 +1112,7 @@ dependencies = [
 [[package]]
 name = "fe-derive"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1620,7 +1620,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "base32",
  "byte-unit",
@@ -1640,7 +1640,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "candid",
  "serde",
@@ -1650,7 +1650,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "ic-protobuf",
  "serde",
@@ -1681,12 +1681,12 @@ dependencies = [
 [[package]]
 name = "ic-constants"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "hex",
  "ic-types 0.8.0",
@@ -1696,7 +1696,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "base64 0.11.0",
  "curve25519-dalek",
@@ -1717,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12381-common"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "bls12_381",
  "getrandom 0.2.7",
@@ -1733,7 +1733,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12381-serde-miracl"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "ic-crypto-internal-types",
  "miracl_core_bls12381",
@@ -1742,7 +1742,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-fs-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "hex",
  "ic-crypto-internal-bls12381-common",
@@ -1758,7 +1758,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -1766,7 +1766,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "base64 0.11.0",
  "bls12_381",
@@ -1786,7 +1786,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "hex",
  "ic-crypto-sha",
@@ -1800,7 +1800,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "openssl",
  "sha2 0.9.9",
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "arrayvec",
  "base64 0.11.0",
@@ -1840,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381-der"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "simple_asn1",
 ]
@@ -1848,7 +1848,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "fe-derive",
  "hex",
@@ -1874,7 +1874,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "arrayvec",
  "base64 0.11.0",
@@ -1892,7 +1892,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -1911,7 +1911,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "serde",
  "zeroize",
@@ -1920,7 +1920,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -1928,7 +1928,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "chrono",
  "dfn_core",
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha",
@@ -1956,7 +1956,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "base64 0.11.0",
  "ed25519-consensus",
@@ -1971,7 +1971,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "serde",
  "strum 0.23.0",
@@ -1981,7 +1981,7 @@ dependencies = [
 [[package]]
 name = "ic-ic00-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "candid",
  "float-cmp",
@@ -1998,9 +1998,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-ledger-canister-core"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
+dependencies = [
+ "async-trait",
+ "candid",
+ "ic-base-types",
+ "ic-constants",
+ "ic-ic00-types",
+ "ic-ledger-core",
+ "ic-utils",
+ "serde",
+]
+
+[[package]]
 name = "ic-ledger-core"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "async-trait",
  "candid",
@@ -2017,12 +2032,12 @@ dependencies = [
 [[package]]
 name = "ic-metrics-encoder"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2044,12 +2059,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "ed25519-dalek",
  "ic-base-types",
@@ -2062,7 +2077,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -2079,7 +2094,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "candid",
  "comparable",
@@ -2102,7 +2117,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "ic-base-types",
  "lazy_static",
@@ -2111,7 +2126,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "bincode",
  "candid",
@@ -2126,7 +2141,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2138,7 +2153,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2149,7 +2164,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "candid",
  "ic-ic00-types",
@@ -2160,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -2172,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "bytes",
  "candid",
@@ -2184,13 +2199,14 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "async-trait",
  "build-info",
  "build-info-build",
  "bytes",
  "candid",
+ "clap",
  "comparable",
  "csv",
  "dfn_candid",
@@ -2224,7 +2240,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2261,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "hex",
  "ic-crypto-sha",
@@ -2290,7 +2306,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "base32",
  "base64 0.11.0",
@@ -2330,7 +2346,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "bitflags",
  "cvt",
@@ -2487,7 +2503,7 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 [[package]]
 name = "ledger-canister"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -2506,6 +2522,7 @@ dependencies = [
  "ic-constants",
  "ic-crypto-sha",
  "ic-ic00-types",
+ "ic-ledger-canister-core",
  "ic-ledger-core",
  "ic-metrics-encoder",
  "ic-nns-constants",
@@ -3010,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 
 [[package]]
 name = "once_cell"
@@ -3175,7 +3192,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "candid",
  "serde",
@@ -3544,7 +3561,7 @@ checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 [[package]]
 name = "registry-canister"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=ef47af542ec54b8e7c28559e8f922585eea53873#ef47af542ec54b8e7c28559e8f922585eea53873"
+source = "git+https://github.com/dfinity/ic?rev=aefcc5ab547578ec81853262757c6224a0d6cf9f#aefcc5ab547578ec81853262757c6224a0d6cf9f"
 dependencies = [
  "build-info",
  "build-info-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,13 @@ clap = { version = "3.1.6", features = ["derive", "cargo"] }
 flate2 = "1.0.22"
 hex = {version = "0.4.2", features = ["serde"] }
 ic-agent = "0.15.0"
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "ef47af542ec54b8e7c28559e8f922585eea53873" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "ef47af542ec54b8e7c28559e8f922585eea53873" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "ef47af542ec54b8e7c28559e8f922585eea53873" }
-ic-sns-governance = { git = "https://github.com/dfinity/ic", rev = "ef47af542ec54b8e7c28559e8f922585eea53873" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "ef47af542ec54b8e7c28559e8f922585eea53873" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "aefcc5ab547578ec81853262757c6224a0d6cf9f" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "aefcc5ab547578ec81853262757c6224a0d6cf9f" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "aefcc5ab547578ec81853262757c6224a0d6cf9f" }
+ic-sns-governance = { git = "https://github.com/dfinity/ic", rev = "aefcc5ab547578ec81853262757c6224a0d6cf9f" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "aefcc5ab547578ec81853262757c6224a0d6cf9f" }
 ic-types = "0.3.0"
-ledger-canister = { git = "https://github.com/dfinity/ic", rev = "ef47af542ec54b8e7c28559e8f922585eea53873" }
+ledger-canister = { git = "https://github.com/dfinity/ic", rev = "aefcc5ab547578ec81853262757c6224a0d6cf9f" }
 libsecp256k1 = "0.7.0"
 num-bigint = { version = "0.4.3", features = ["serde"] }
 openssl = "0.10.32"

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,6 +11,7 @@ mod configure_dissolve_delay;
 mod generate;
 mod make_proposal;
 mod make_upgrade_canister_proposal;
+mod neuron_permission;
 mod public;
 mod qrcode;
 mod register_vote;
@@ -59,6 +60,8 @@ pub enum Command {
     /// Signs a ManageNeuron message to submit a UpgradeSnsControlledCanister
     /// proposal.
     MakeUpgradeCanisterProposal(make_upgrade_canister_proposal::MakeUpgradeCanisterProposalOpts),
+    /// Signs a ManageNeuron message to add or remove neuron permissions to/from a specified principal.
+    NeuronPermission(neuron_permission::NeuronPermissionOpts),
 }
 
 pub fn exec(
@@ -99,6 +102,11 @@ pub fn exec(
             let pem = require_pem(private_key_pem)?;
             let canister_ids = require_canister_ids(sns_canister_ids)?;
             register_vote::exec(&pem, &canister_ids, opts).and_then(|out| print_vec(qr, &out))
+        }
+        Command::NeuronPermission(opts) => {
+            let pem = require_pem(private_key_pem)?;
+            let canister_ids = require_canister_ids(sns_canister_ids)?;
+            neuron_permission::exec(&pem, &canister_ids, opts).and_then(|out| print_vec(qr, &out))
         }
         Command::Generate(opts) => generate::exec(opts),
         // QR code for URL: https://p5deo-6aaaa-aaaab-aaaxq-cai.raw.ic0.app/

--- a/src/commands/neuron_permission.rs
+++ b/src/commands/neuron_permission.rs
@@ -4,7 +4,7 @@ use clap::{ArgEnum, Parser};
 use ic_base_types::PrincipalId;
 use ic_sns_governance::pb::v1::{
     manage_neuron::{AddNeuronPermissions, Command, RemoveNeuronPermissions},
-    ManageNeuron, NeuronPermissionList,
+    ManageNeuron, NeuronPermissionList, NeuronPermissionType,
 };
 
 use crate::{
@@ -38,19 +38,7 @@ pub struct NeuronPermissionOpts {
         min_values(1),
         required(true)
     )]
-    permissions: Vec<PermissionType>,
-}
-
-#[derive(ArgEnum, Clone)]
-pub enum PermissionType {
-    ConfigureDissolveState = 1,
-    ManagePrincipals = 2,
-    SubmitProposal = 3,
-    Vote = 4,
-    Disburse = 5,
-    Split = 6,
-    MergeMaturity = 7,
-    DisburseMaturity = 8,
+    permissions: Vec<NeuronPermissionType>,
 }
 
 #[derive(ArgEnum, Clone)]

--- a/src/commands/neuron_permission.rs
+++ b/src/commands/neuron_permission.rs
@@ -1,0 +1,93 @@
+use anyhow::anyhow;
+use candid::Encode;
+use clap::{ArgEnum, Parser};
+use ic_base_types::PrincipalId;
+use ic_sns_governance::pb::v1::{
+    manage_neuron::{AddNeuronPermissions, Command, RemoveNeuronPermissions},
+    ManageNeuron, NeuronPermissionList,
+};
+
+use crate::{
+    lib::{
+        parse_neuron_id,
+        signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
+        AnyhowResult, TargetCanister,
+    },
+    SnsCanisterIds,
+};
+
+/// Signs a ManageNeuron message to add or remove permissions for a principal to/from a neuron.
+/// This will selectively enable/disable that principal to do a variety of management tasks for the neuron, including voting and disbursing.
+#[derive(Parser)]
+pub struct NeuronPermissionOpts {
+    /// Whether to add or remove permissions.
+    #[clap(arg_enum)]
+    subcommand: Subcmd,
+    /// The id of the neuron to configure as a hex encoded string. For example:
+    /// 83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
+    neuron_id: String,
+    /// The principal to change the permissions of.
+    #[clap(long)]
+    principal: PrincipalId,
+    /// The permissions to add to/remove from the principal. You can specify multiple in one command.
+    #[clap(
+        long,
+        multiple_values(true),
+        use_value_delimiter(true),
+        arg_enum,
+        min_values(1),
+        required(true)
+    )]
+    permissions: Vec<PermissionType>,
+}
+
+#[derive(ArgEnum, Clone)]
+pub enum PermissionType {
+    ConfigureDissolveState = 1,
+    ManagePrincipals = 2,
+    SubmitProposal = 3,
+    Vote = 4,
+    Disburse = 5,
+    Split = 6,
+    MergeMaturity = 7,
+    DisburseMaturity = 8,
+}
+
+#[derive(ArgEnum, Clone)]
+enum Subcmd {
+    Add,
+    Remove,
+}
+
+pub fn exec(
+    pem: &str,
+    canister_ids: &SnsCanisterIds,
+    opts: NeuronPermissionOpts,
+) -> AnyhowResult<Vec<IngressWithRequestId>> {
+    let id = parse_neuron_id(opts.neuron_id)?;
+    let neuron_subaccount = id.subaccount().map_err(|e| anyhow!(e))?;
+    let permission_list = NeuronPermissionList {
+        permissions: opts.permissions.into_iter().map(|x| x as i32).collect(),
+    };
+    let req = ManageNeuron {
+        subaccount: neuron_subaccount.to_vec(),
+        command: Some(if let Subcmd::Add = opts.subcommand {
+            Command::AddNeuronPermissions(AddNeuronPermissions {
+                principal_id: Some(opts.principal),
+                permissions_to_add: Some(permission_list),
+            })
+        } else {
+            Command::RemoveNeuronPermissions(RemoveNeuronPermissions {
+                principal_id: Some(opts.principal),
+                permissions_to_remove: Some(permission_list),
+            })
+        }),
+    };
+    let msg = sign_ingress_with_request_status_query(
+        pem,
+        "manage_neuron",
+        Encode!(&req)?,
+        TargetCanister::Governance(canister_ids.governance_canister_id.get().0),
+    )?;
+    Ok(vec![msg])
+}

--- a/tests/commands/neuron-permission-add.sh
+++ b/tests/commands/neuron-permission-add.sh
@@ -1,0 +1,2 @@
+NEURON_ID=83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - neuron-permission add $NEURON_ID --principal fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae --permissions submit-proposal,vote | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -

--- a/tests/commands/neuron-permission-remove.sh
+++ b/tests/commands/neuron-permission-remove.sh
@@ -1,0 +1,2 @@
+NEURON_ID=83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - neuron-permission remove $NEURON_ID --principal fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae --permissions merge-maturity disburse-maturity | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -

--- a/tests/outputs/neuron-permission-add.txt
+++ b/tests/outputs/neuron-permission-add.txt
@@ -1,0 +1,19 @@
+Sending message with
+
+  Call type:   update
+  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
+  Method name: manage_neuron
+  Arguments:   (
+  record {
+    subaccount = blob "\83\a7\d2\b1/eO\f5\835\e5\a2Q,\ca\e0\d7\83\9ctK\18\07\a4|\96\f5\b9\f3\96\90i";
+    command = opt variant {
+      AddNeuronPermissions = record {
+        permissions_to_add = opt record {
+          permissions = vec { 3 : int32; 4 : int32 };
+        };
+        principal_id = opt principal "fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae";
+      }
+    };
+  },
+)

--- a/tests/outputs/neuron-permission-remove.txt
+++ b/tests/outputs/neuron-permission-remove.txt
@@ -1,0 +1,19 @@
+Sending message with
+
+  Call type:   update
+  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
+  Method name: manage_neuron
+  Arguments:   (
+  record {
+    subaccount = blob "\83\a7\d2\b1/eO\f5\835\e5\a2Q,\ca\e0\d7\83\9ctK\18\07\a4|\96\f5\b9\f3\96\90i";
+    command = opt variant {
+      RemoveNeuronPermissions = record {
+        permissions_to_remove = opt record {
+          permissions = vec { 7 : int32; 8 : int32 };
+        };
+        principal_id = opt principal "fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae";
+      }
+    };
+  },
+)


### PR DESCRIPTION
This adds `sns-quill neuron-permission add` and `sns-quill neuron-permission remove`, corresponding to ManageNeuron's `Command::AddNeuronPermission` and `Command::RemoveNeuronPermission`.

Implements SDK-556.