### PR TITLE
chore: Add rust-toolchain.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           VCPKG_ROOT: 'C:\vcpkg'
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1.0.6
         with:
           profile: minimal
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable]
         task: [check, fmt, clippy, test]
     steps:
       - uses: actions/checkout@master
@@ -29,8 +28,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
-          components: rustfmt, clippy
   
       - name: ${{ matrix.task }}
         run: make ${{ matrix.task }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
           components: rustfmt, clippy
   
       - name: ${{ matrix.task }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        rust: ['1.60.0']
         task: [check, fmt, clippy, test]
     steps:
       - uses: actions/checkout@master
@@ -25,9 +26,11 @@ jobs:
         env:
           VCPKG_ROOT: 'C:\vcpkg'
 
-      - uses: actions-rs/toolchain@v1.0.6
+      - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          toolchain: ${{ matrix.rust }}
+          components: rustfmt, clippy
   
       - name: ${{ matrix.task }}
         run: make ${{ matrix.task }}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.60.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This will fix failing CI; 1.62 has a breaking change for Tokio that has yet to be fixed.