### PR TITLE
feat: Move all the args to the end

### DIFF
--- a/src/commands/account_balance.rs
+++ b/src/commands/account_balance.rs
@@ -1,6 +1,4 @@
-use crate::{
-    commands::send::send_unsigned_ingress, lib::TargetCanister, AnyhowResult, SnsCanisterIds,
-};
+use crate::{commands::send::send_unsigned_ingress, lib::TargetCanister, AnyhowResult, IdsOpt};
 use anyhow::Error;
 use candid::Encode;
 use clap::Parser;
@@ -16,11 +14,15 @@ pub struct AccountBalanceOpts {
     /// Will display the query, but not send it
     #[clap(long)]
     dry_run: bool,
+
+    #[clap(flatten)]
+    sns_canister_ids: IdsOpt,
 }
 
-pub async fn exec(sns_canister_ids: &SnsCanisterIds, opts: AccountBalanceOpts) -> AnyhowResult {
+pub async fn exec(opts: AccountBalanceOpts) -> AnyhowResult {
     let account_identifier = AccountIdentifier::from_hex(&opts.account_id).map_err(Error::msg)?;
-    let ledger_canister_id = PrincipalId::from(sns_canister_ids.ledger_canister_id).0;
+    let ledger_canister_id =
+        PrincipalId::from(opts.sns_canister_ids.to_ids()?.ledger_canister_id).0;
 
     let args = Encode!(&BinaryAccountBalanceArgs {
         account: account_identifier.to_address()

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1,9 +1,9 @@
 use crate::lib::{mnemonic_to_pem, AnyhowResult};
-use anyhow::{anyhow, Context};
+use anyhow::{bail, Context};
 use bip39::{Language, Mnemonic};
 use clap::Parser;
 use rand::{rngs::OsRng, RngCore};
-use std::path::Path;
+use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
 #[clap(about, version, author)]
@@ -14,11 +14,11 @@ pub struct GenerateOpts {
 
     /// File to write the seed phrase to.
     #[clap(long, default_value = "seed.txt")]
-    seed_file: String,
+    seed_file: PathBuf,
 
     /// File to write the PEM to.
     #[clap(long)]
-    pem_file: Option<String>,
+    pem_file: Option<PathBuf>,
 
     /// A seed phrase in quotes to use to generate the PEM file.
     #[clap(long)]
@@ -35,18 +35,18 @@ pub struct GenerateOpts {
 
 /// Generate or recover mnemonic seed phrase and/or PEM file.
 pub fn exec(opts: GenerateOpts) -> AnyhowResult {
-    if Path::new(&opts.seed_file).exists() && !opts.overwrite_seed_file {
-        return Err(anyhow!("Seed file exists and overwrite is not set."));
+    if opts.seed_file.exists() && !opts.overwrite_seed_file {
+        bail!("Seed file exists and overwrite is not set.");
     }
     if let Some(path) = &opts.pem_file {
-        if Path::new(path).exists() && !opts.overwrite_pem_file {
-            return Err(anyhow!("PEM file exists and overwrite is not set."));
+        if path.exists() && !opts.overwrite_pem_file {
+            bail!("PEM file exists and overwrite is not set.");
         }
     }
     let bytes = match opts.words {
         12 => 16,
         24 => 32,
-        _ => return Err(anyhow!("Words must be 12 or 24.")),
+        _ => bail!("Words must be 12 or 24."),
     };
     let mnemonic = match opts.phrase {
         Some(phrase) => Mnemonic::parse(phrase).context("Failed to parse mnemonic")?,
@@ -64,9 +64,9 @@ pub fn exec(opts: GenerateOpts) -> AnyhowResult {
     phrase.push('\n');
     std::fs::write(opts.seed_file, phrase)?;
     if let Some(path) = opts.pem_file {
-        std::fs::write(path, pem.clone())?;
+        std::fs::write(path, &pem)?;
     }
-    let (principal_id, account_id) = crate::commands::public::get_ids(&Some(pem))?;
+    let (principal_id, account_id) = crate::commands::public::get_ids(&pem)?;
     println!("Principal id: {}", principal_id);
     println!("Account id: {}", account_id);
     Ok(())

--- a/src/commands/get_swap_refund.rs
+++ b/src/commands/get_swap_refund.rs
@@ -3,14 +3,11 @@ use clap::Parser;
 use ic_sns_swap::pb::v1::ErrorRefundIcpRequest;
 
 use crate::{
-    lib::{
-        signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
-        AnyhowResult, TargetCanister,
-    },
-    SnsCanisterIds,
+    lib::{signing::sign_ingress_with_request_status_query, AnyhowResult, TargetCanister},
+    IdsOpt, PemOpts, QrOpt,
 };
 
-use super::transfer;
+use super::transfer::ParsedTokens;
 
 /// Signs a message to request a refund from the SNS swap canister.
 /// If the swap was aborted or failed, or some of your contributed ICP never made it into a neuron,
@@ -19,32 +16,34 @@ use super::transfer;
 pub struct GetSwapRefundOpts {
     /// The amount of ICP to request a refund for.
     #[clap(long)]
-    amount: String,
+    amount: ParsedTokens,
     /// The expected transaction fee. If omitted, defaults to 0.0001 ICP.
     #[clap(long)]
-    fee: Option<String>,
+    fee: Option<ParsedTokens>,
+
+    #[clap(flatten)]
+    pem: PemOpts,
+    #[clap(flatten)]
+    sns_canister_ids: IdsOpt,
+    #[clap(flatten)]
+    qr: QrOpt,
 }
 
-pub fn exec(
-    pem: &str,
-    sns_canister_ids: &SnsCanisterIds,
-    opts: GetSwapRefundOpts,
-) -> AnyhowResult<Vec<IngressWithRequestId>> {
-    let tokens = transfer::parse_tokens(&opts.amount)?.get_e8s();
-    let fee = opts
-        .fee
-        .map(|fee| anyhow::Ok(transfer::parse_tokens(&fee)?.get_e8s()))
-        .transpose()?
-        .unwrap_or(10_000);
+pub fn exec(opts: GetSwapRefundOpts) -> AnyhowResult {
+    let pem = opts.pem.to_pem()?;
+    let sns_canister_ids = opts.sns_canister_ids.to_ids()?;
+    let tokens = opts.amount.0.get_e8s();
+    let fee = opts.fee.map(|fee| fee.0.get_e8s()).unwrap_or(10_000);
     let message = ErrorRefundIcpRequest {
         icp_e8s: tokens,
         fee_override_e8s: fee,
     };
     let req = sign_ingress_with_request_status_query(
-        pem,
+        &pem,
         "error_refund_icp",
         Encode!(&message)?,
         TargetCanister::Swap(sns_canister_ids.swap_canister_id.get().0),
     )?;
-    Ok(vec![req])
+    super::print_vec(opts.qr.qr, &[req])?;
+    Ok(())
 }

--- a/src/commands/public.rs
+++ b/src/commands/public.rs
@@ -1,4 +1,7 @@
-use crate::lib::{get_account_id, get_identity, require_pem, AnyhowResult};
+use crate::{
+    lib::{get_account_id, get_identity, AnyhowResult},
+    PemOpts,
+};
 use anyhow::anyhow;
 use clap::Parser;
 use ic_types::principal::Principal;
@@ -9,33 +12,31 @@ pub struct PublicOpts {
     /// Principal for which to get the account_id.
     #[clap(long)]
     principal_id: Option<String>,
+    #[clap(flatten)]
+    pem: PemOpts,
 }
 
 /// Prints the account and the principal ids.
-pub fn exec(pem: &Option<String>, opts: PublicOpts) -> AnyhowResult {
-    let (principal_id, account_id) = get_public_ids(pem, opts)?;
+pub fn exec(opts: PublicOpts) -> AnyhowResult {
+    let (principal_id, account_id) = get_public_ids(opts)?;
     println!("Principal id: {}", principal_id.to_text());
     println!("Account id: {}", account_id);
     Ok(())
 }
 
 /// Returns the account id and the principal id if the private key was provided.
-fn get_public_ids(
-    pem: &Option<String>,
-    opts: PublicOpts,
-) -> AnyhowResult<(Principal, AccountIdentifier)> {
+fn get_public_ids(opts: PublicOpts) -> AnyhowResult<(Principal, AccountIdentifier)> {
     match opts.principal_id {
         Some(principal_id) => {
             let principal_id = ic_types::Principal::from_text(principal_id)?;
             Ok((principal_id, get_account_id(principal_id)?))
         }
-        None => get_ids(pem),
+        None => get_ids(&opts.pem.to_pem()?),
     }
 }
 
 /// Returns the account id and the principal id if the private key was provided.
-pub fn get_ids(pem: &Option<String>) -> AnyhowResult<(Principal, AccountIdentifier)> {
-    let pem = require_pem(pem)?;
-    let principal_id = get_identity(&pem).sender().map_err(|e| anyhow!(e))?;
+pub fn get_ids(pem: &str) -> AnyhowResult<(Principal, AccountIdentifier)> {
+    let principal_id = get_identity(pem).sender().map_err(|e| anyhow!(e))?;
     Ok((principal_id, get_account_id(principal_id)?))
 }

--- a/src/commands/qrcode.rs
+++ b/src/commands/qrcode.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use crate::lib::{qr::print_qr, read_from_file, AnyhowResult};
 use clap::Parser;
 
@@ -5,7 +7,7 @@ use clap::Parser;
 pub struct QRCodeOpts {
     /// File the contents of which to be output as a QRCode.
     #[clap(long)]
-    file: Option<String>,
+    file: Option<PathBuf>,
 
     // String to be output as a QRCode.
     #[clap(long)]

--- a/src/commands/register_vote.rs
+++ b/src/commands/register_vote.rs
@@ -1,10 +1,6 @@
 use crate::{
-    lib::{
-        parse_neuron_id,
-        signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
-        TargetCanister,
-    },
-    AnyhowResult, SnsCanisterIds,
+    lib::{parse_neuron_id, signing::sign_ingress_with_request_status_query, TargetCanister},
+    AnyhowResult, IdsOpt, PemOpts, QrOpt,
 };
 use anyhow::{anyhow, Error};
 use candid::Encode;
@@ -30,13 +26,18 @@ pub struct RegisterVoteOpts {
     #[clap(long)]
     /// The vote to be cast on the proposal [y/n]
     vote: String,
+
+    #[clap(flatten)]
+    pem: PemOpts,
+    #[clap(flatten)]
+    sns_canister_ids: IdsOpt,
+    #[clap(flatten)]
+    qr: QrOpt,
 }
 
-pub fn exec(
-    private_key_pem: &str,
-    sns_canister_ids: &SnsCanisterIds,
-    opts: RegisterVoteOpts,
-) -> AnyhowResult<Vec<IngressWithRequestId>> {
+pub fn exec(opts: RegisterVoteOpts) -> AnyhowResult {
+    let private_key_pem = opts.pem.to_pem()?;
+    let sns_canister_ids = opts.sns_canister_ids.to_ids()?;
     let id = parse_neuron_id(opts.neuron_id)?;
     let neuron_subaccount = id.subaccount().map_err(Error::msg)?;
     let governance_canister_id = sns_canister_ids.governance_canister_id.get().0;
@@ -60,11 +61,12 @@ pub fn exec(
     })?;
 
     let msg = sign_ingress_with_request_status_query(
-        private_key_pem,
+        &private_key_pem,
         "manage_neuron",
         args,
         TargetCanister::Governance(governance_canister_id),
     )?;
 
-    Ok(vec![msg])
+    super::print_vec(opts.qr.qr, &[msg])?;
+    Ok(())
 }

--- a/src/commands/request_status.rs
+++ b/src/commands/request_status.rs
@@ -9,7 +9,7 @@ use ic_agent::{
 use ic_types::Principal;
 use std::{future::Future, pin::Pin, str::FromStr, sync::Arc};
 
-pub async fn submit(req: &RequestStatus) -> AnyhowResult<Vec<u8>> {
+pub async fn submit(req: RequestStatus) -> AnyhowResult<Vec<u8>> {
     let canister_id =
         Principal::from_text(&req.canister_id).context("Cannot parse the canister id")?;
     let request_id = RequestId::from_str(&req.request_id).context("Cannot parse the request_id")?;
@@ -90,9 +90,9 @@ impl ReplicaV2Transport for ProxySignReplicaV2Transport {
         _content: Vec<u8>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, AgentError>> + Send + 'a>> {
         async fn run(transport: &ProxySignReplicaV2Transport) -> Result<Vec<u8>, AgentError> {
-            let canister_id = Principal::from_text(transport.req.canister_id.clone())
+            let canister_id = Principal::from_text(&transport.req.canister_id)
                 .map_err(|err| MessageError(format!("Unable to parse canister_id: {:?}", err)))?;
-            let envelope = hex::decode(transport.req.content.clone()).map_err(|err| {
+            let envelope = hex::decode(&transport.req.content).map_err(|err| {
                 MessageError(format!(
                     "Unable to decode request content (should be hexadecimal encoded): {}",
                     err

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -4,7 +4,7 @@ use ic_sns_swap::pb::v1::GetCanisterStatusRequest;
 
 use crate::{
     lib::{AnyhowResult, TargetCanister},
-    SnsCanisterIds,
+    IdsOpt,
 };
 
 use super::send::send_unsigned_ingress;
@@ -16,10 +16,13 @@ pub struct StatusOpts {
     /// Will display the query, but not send it.
     #[clap(long)]
     dry_run: bool,
+
+    #[clap(flatten)]
+    ids: IdsOpt,
 }
 
-pub async fn exec(ids: &SnsCanisterIds, opts: StatusOpts) -> AnyhowResult {
-    let root_canister_id = ids.root_canister_id.get().0;
+pub async fn exec(opts: StatusOpts) -> AnyhowResult {
+    let root_canister_id = opts.ids.to_ids()?.root_canister_id.get().0;
     let arg = Encode!(&GetCanisterStatusRequest {})?;
     send_unsigned_ingress(
         "get_sns_canisters_summary",

--- a/src/commands/transfer.rs
+++ b/src/commands/transfer.rs
@@ -1,9 +1,11 @@
+use std::str::FromStr;
+
 use crate::{
     lib::{
         signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
         AnyhowResult, TargetCanister,
     },
-    SnsCanisterIds,
+    IdsOpt, PemOpts, QrOpt, SnsCanisterIds,
 };
 use anyhow::{anyhow, bail, Context, Error};
 use candid::Encode;
@@ -12,60 +14,75 @@ use ic_base_types::PrincipalId;
 use ledger_canister::{AccountIdentifier, Memo, Tokens, TransferArgs, DEFAULT_TRANSFER_FEE};
 
 /// Signs a ledger transfer update call.
-#[derive(Default, Parser)]
+#[derive(Parser)]
 pub struct TransferOpts {
     /// The AccountIdentifier of the destination account. For example: d5662fbce449fbd4adb4b9aff6c59035bd93e7c2eff5010a446ebc3dd81007f8
     pub to: String,
 
     /// Amount of governance tokens to transfer (with up to 8 decimal digits after decimal point)
-    #[clap(long, validator(tokens_amount_validator))]
-    pub amount: String,
+    #[clap(long)]
+    pub amount: ParsedTokens,
 
     /// An arbitrary number associated with a transaction. The default is 0
-    #[clap(long, validator(memo_validator))]
-    pub memo: Option<String>,
+    #[clap(long)]
+    pub memo: Option<u64>,
 
     /// The amount that the caller pays for the transaction, default is 10_000 e8s. Specify this amount
     /// when using an SNS that sets its own transaction fee
-    #[clap(long, validator(tokens_amount_validator))]
-    pub fee: Option<String>,
+    #[clap(long)]
+    pub fee: Option<ParsedTokens>,
+
+    #[clap(flatten)]
+    pem: PemOpts,
+    #[clap(flatten)]
+    sns_canister_ids: IdsOpt,
+    #[clap(flatten)]
+    qr: QrOpt,
 }
 
-pub fn exec(
-    private_key_pem: &str,
-    sns_canister_ids: &SnsCanisterIds,
-    opts: TransferOpts,
-) -> AnyhowResult<Vec<IngressWithRequestId>> {
-    let amount = parse_tokens(&opts.amount).context("Cannot parse amount")?;
-    let fee = opts.fee.map_or(Ok(DEFAULT_TRANSFER_FEE), |fee| {
-        parse_tokens(&fee).context("Cannot parse fee")
-    })?;
-    let memo = Memo(
-        opts.memo
-            .unwrap_or_else(|| "0".to_string())
-            .parse::<u64>()
-            .context("Failed to parse memo as unsigned integer")?,
-    );
-    let ledger_canister_id = PrincipalId::from(sns_canister_ids.ledger_canister_id).0;
+pub fn exec(opts: TransferOpts) -> AnyhowResult {
+    let amount = opts.amount.0;
+    let private_key_pem = opts.pem.to_pem()?;
+    let sns_canister_ids = opts.sns_canister_ids.to_ids()?;
+    let fee = opts.fee.map_or(DEFAULT_TRANSFER_FEE, |fee| fee.0);
+    let memo = Memo(opts.memo.unwrap_or(0));
     let to_account_identifier = AccountIdentifier::from_hex(&opts.to).map_err(Error::msg)?;
+    let msg = sign_transfer(
+        &sns_canister_ids,
+        &private_key_pem,
+        &to_account_identifier,
+        amount,
+        fee,
+        memo,
+    )?;
+    super::print_vec(opts.qr.qr, &[msg])?;
+    Ok(())
+}
 
+pub fn sign_transfer(
+    sns_canister_ids: &SnsCanisterIds,
+    private_key_pem: &str,
+    to: &AccountIdentifier,
+    amount: Tokens,
+    fee: Tokens,
+    memo: Memo,
+) -> AnyhowResult<IngressWithRequestId> {
     let args = Encode!(&TransferArgs {
         memo,
         amount,
         fee,
         from_subaccount: None,
-        to: to_account_identifier.to_address(),
+        to: to.to_address(),
         created_at_time: None,
     })?;
-
+    let ledger_canister_id = PrincipalId::from(sns_canister_ids.ledger_canister_id).0;
     let msg = sign_ingress_with_request_status_query(
         private_key_pem,
         "transfer",
         args,
         TargetCanister::Ledger(ledger_canister_id),
     )?;
-
-    Ok(vec![msg])
+    Ok(msg)
 }
 
 fn new_tokens(tokens: u64, e8s: u64) -> AnyhowResult<Tokens> {
@@ -74,33 +91,27 @@ fn new_tokens(tokens: u64, e8s: u64) -> AnyhowResult<Tokens> {
         .context("Cannot create new Tokens")
 }
 
-pub fn parse_tokens(amount: &str) -> AnyhowResult<Tokens> {
-    let parse_u64 = |s: &str| {
-        s.parse::<u64>()
-            .context("Failed to parse Tokens as unsigned integer")
-    };
-    match &amount.split('.').collect::<Vec<_>>().as_slice() {
-        [tokens] => new_tokens(parse_u64(tokens)?, 0),
-        [tokens, e8s] => {
-            let mut e8s = e8s.to_string();
-            // Pad e8s with zeros on the right so that its length is 8.
-            while e8s.len() < 8 {
-                e8s.push('0');
+pub struct ParsedTokens(pub Tokens);
+
+impl FromStr for ParsedTokens {
+    type Err = anyhow::Error;
+    fn from_str(amount: &str) -> AnyhowResult<Self> {
+        let parse_u64 = |s: &str| {
+            s.parse::<u64>()
+                .context("Failed to parse Tokens as unsigned integer")
+        };
+        match &amount.split('.').collect::<Vec<_>>().as_slice() {
+            [tokens] => new_tokens(parse_u64(tokens)?, 0).map(Self),
+            [tokens, e8s] => {
+                let mut e8s = e8s.to_string();
+                // Pad e8s with zeros on the right so that its length is 8.
+                while e8s.len() < 8 {
+                    e8s.push('0');
+                }
+                let e8s = &e8s[..8];
+                new_tokens(parse_u64(tokens)?, parse_u64(e8s)?).map(Self)
             }
-            let e8s = &e8s[..8];
-            new_tokens(parse_u64(tokens)?, parse_u64(e8s)?)
+            _ => bail!("Cannot parse amount {}", amount),
         }
-        _ => bail!("Cannot parse amount {}", amount),
     }
-}
-
-fn tokens_amount_validator(tokens: &str) -> AnyhowResult<()> {
-    parse_tokens(tokens).map(|_| ())
-}
-
-fn memo_validator(memo: &str) -> Result<(), String> {
-    if memo.parse::<u64>().is_ok() {
-        return Ok(());
-    }
-    Err("Memo must be an unsigned integer".to_string())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,18 @@
 #![warn(unused_extern_crates)]
 
 use crate::lib::AnyhowResult;
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow, bail, Context};
 use bip39::Mnemonic;
-use clap::{crate_version, Parser};
+use clap::{crate_version, Args, Parser};
 use ic_base_types::CanisterId;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{collections::HashMap, fs::File, path::PathBuf, str::FromStr};
+use std::{
+    collections::HashMap,
+    fs::File,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 mod commands;
 mod lib;
@@ -16,18 +21,29 @@ mod lib;
 #[derive(Parser)]
 #[clap(name("sns-quill"), version = crate_version!())]
 pub struct CliOpts {
+    #[clap(subcommand)]
+    command: commands::Command,
+}
+
+#[derive(Args)]
+pub struct PemOpts {
     /// Path to your PEM file (use "-" for STDIN)
     #[clap(long)]
-    pem_file: Option<String>,
+    pem_file: Option<PathBuf>,
 
     /// Path to your seed file (use "-" for STDIN)
     #[clap(long)]
-    seed_file: Option<String>,
+    seed_file: Option<PathBuf>,
+}
 
-    /// Output the result(s) as UTF-8 QR codes.
-    #[clap(long)]
-    qr: bool,
+impl PemOpts {
+    fn to_pem(&self) -> AnyhowResult<String> {
+        read_pem(self.pem_file.as_deref(), self.seed_file.as_deref())
+    }
+}
 
+#[derive(Args)]
+pub struct IdsOpt {
     /// Path to the JSON file containing the SNS cluster's canister ids. This is a JSON
     /// file containing a JSON map of canister names to canister IDs.
     ///
@@ -41,10 +57,20 @@ pub struct CliOpts {
     ///.   ],
     /// }
     #[clap(long)]
-    canister_ids_file: Option<String>,
+    canister_ids_file: PathBuf,
+}
 
-    #[clap(subcommand)]
-    command: commands::Command,
+impl IdsOpt {
+    fn to_ids(&self) -> AnyhowResult<SnsCanisterIds> {
+        read_sns_canister_ids(&self.canister_ids_file)
+    }
+}
+
+#[derive(Args)]
+pub struct QrOpt {
+    /// Output the result(s) as UTF-8 QR codes.
+    #[clap(long)]
+    qr: bool,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -56,40 +82,22 @@ pub struct SnsCanisterIds {
     pub dapp_canister_id_list: Vec<CanisterId>,
 }
 
-fn main() {
+fn main() -> AnyhowResult {
     let opts = CliOpts::parse();
-    if let Err(err) = run(opts) {
-        for (level, cause) in err.chain().enumerate() {
-            if level == 0 {
-                eprintln!("Error: {}", err);
-                continue;
-            }
-            if level == 1 {
-                eprintln!("Caused by:");
-            }
-            eprintln!("{:width$}{}", "", cause, width = level * 2);
-        }
-        std::process::exit(1);
-    }
-}
-
-fn run(opts: CliOpts) -> AnyhowResult<()> {
-    let pem = read_pem(opts.pem_file, opts.seed_file)?;
-    let canister_ids = read_sns_canister_ids(opts.canister_ids_file)?;
-    commands::exec(&pem, &canister_ids, opts.qr, opts.command)
+    commands::dispatch(opts.command)
 }
 
 /// Get PEM from the file if provided, or try to convert from the seed file
-fn read_pem(pem_file: Option<String>, seed_file: Option<String>) -> AnyhowResult<Option<String>> {
+fn read_pem(pem_file: Option<&Path>, seed_file: Option<&Path>) -> AnyhowResult<String> {
     match (pem_file, seed_file) {
-        (Some(pem_file), _) => read_file(&pem_file, "PEM").map(Some),
+        (Some(pem_file), _) => read_file(&pem_file, "PEM"),
         (_, Some(seed_file)) => {
             let seed = read_file(&seed_file, "seed")?;
             let mnemonic = parse_mnemonic(&seed)?;
             let mnemonic = lib::mnemonic_to_pem(&mnemonic)?;
-            Ok(Some(mnemonic))
+            Ok(mnemonic)
         }
-        _ => Ok(None),
+        _ => bail!("Either the PEM file or the seed file must be provided"),
     }
 }
 
@@ -101,17 +109,9 @@ fn read_pem(pem_file: Option<String>, seed_file: Option<String>) -> AnyhowResult
 ///   3. root_canister_id
 ///   4. dapp_canister_id_list (array)
 ///
-/// If no file_path is provided (i.e. not provided as input to the command), do nothing and return
-/// Ok(None). If the file_path is provided, but the file is malformed, Err is returned. Else, return
-/// the parsed struct.
-fn read_sns_canister_ids(file_path: Option<String>) -> AnyhowResult<Option<SnsCanisterIds>> {
-    let file_path = match file_path {
-        None => return Ok(None),
-        Some(path) => path,
-    };
-
-    let path = PathBuf::from(file_path);
-    let file = File::open(path).context("Could not open the SNS Canister Ids file")?;
+/// If the file is malformed, Err is returned. Else, return the parsed struct.
+fn read_sns_canister_ids(file_path: &Path) -> AnyhowResult<SnsCanisterIds> {
+    let file = File::open(file_path).context("Could not open the SNS Canister Ids file")?;
     let ids: HashMap<String, Value> =
         serde_json::from_reader(file).context("Could not parse the SNS Canister Ids file")?;
 
@@ -122,13 +122,13 @@ fn read_sns_canister_ids(file_path: Option<String>) -> AnyhowResult<Option<SnsCa
 
     let dapp_canister_id_list = parse_dapp_canister_id_list("dapp_canister_id_list", &ids)?;
 
-    Ok(Some(SnsCanisterIds {
+    Ok(SnsCanisterIds {
         governance_canister_id,
         ledger_canister_id,
         swap_canister_id,
         root_canister_id,
         dapp_canister_id_list,
-    }))
+    })
 }
 
 fn parse_canister_id(
@@ -181,25 +181,18 @@ fn parse_mnemonic(phrase: &str) -> AnyhowResult<Mnemonic> {
     Mnemonic::parse(phrase).context("Couldn't parse the seed phrase as a valid mnemonic. {:?}")
 }
 
-fn read_file(path: &str, name: &str) -> AnyhowResult<String> {
-    match path {
-        // read from STDIN
-        "-" => {
-            let mut buffer = String::new();
-            use std::io::Read;
-            std::io::stdin()
-                .read_to_string(&mut buffer)
-                .map(|_| buffer)
-                .context(format!("Couldn't read {} from STDIN", name))
-        }
-        path => std::fs::read_to_string(path).context(format!("Couldn't read {} file", name)),
+fn read_file(path: impl AsRef<Path>, name: &str) -> AnyhowResult<String> {
+    let path = path.as_ref();
+    if path == Path::new("-") {
+        let mut buffer = String::new();
+        use std::io::Read;
+        std::io::stdin()
+            .read_to_string(&mut buffer)
+            .map(|_| buffer)
+            .context(format!("Couldn't read {} from STDIN", name))
+    } else {
+        std::fs::read_to_string(path).with_context(|| format!("Couldn't read {} file", name))
     }
-}
-
-#[test]
-fn test_read_pem_none_none() {
-    let res = read_pem(None, None);
-    assert_eq!(None, res.expect("read_pem(None, None) failed"));
 }
 
 #[test]
@@ -208,14 +201,14 @@ fn test_read_pem_from_pem_file() {
 
     let mut pem_file = tempfile::NamedTempFile::new().expect("Cannot create temp file");
 
-    let content = "pem".to_string();
+    let content = "pem";
     pem_file
         .write_all(content.as_bytes())
         .expect("Cannot write to temp file");
 
-    let res = read_pem(Some(pem_file.path().to_str().unwrap().to_string()), None);
+    let res = read_pem(Some(pem_file.path()), None);
 
-    assert_eq!(Some(content), res.expect("read_pem from pem file"));
+    assert_eq!(content, res.expect("read_pem from pem file"));
 }
 
 #[test]
@@ -230,9 +223,7 @@ fn test_read_pem_from_seed_file() {
         .expect("Cannot write to temp file");
     let mnemonic = lib::mnemonic_to_pem(&Mnemonic::parse(phrase).unwrap()).unwrap();
 
-    let pem = read_pem(None, Some(seed_file.path().to_str().unwrap().to_string()))
-        .expect("Unable to read seed_file")
-        .expect("None returned instead of Some");
+    let pem = read_pem(None, Some(seed_file.path())).expect("Unable to read seed_file");
 
     assert_eq!(mnemonic, pem);
 }
@@ -240,17 +231,11 @@ fn test_read_pem_from_seed_file() {
 #[test]
 fn test_read_pem_from_non_existing_file() {
     let dir = tempfile::tempdir().expect("Cannot create temp dir");
-    let non_existing_file = dir
-        .path()
-        .join("non_existing_pem_file")
-        .as_path()
-        .to_str()
-        .unwrap()
-        .to_string();
+    let non_existing_file = dir.path().join("non_existing_pem_file");
 
-    read_pem(Some(non_existing_file.clone()), None).unwrap_err();
+    read_pem(Some(&non_existing_file), None).unwrap_err();
 
-    read_pem(None, Some(non_existing_file)).unwrap_err();
+    read_pem(None, Some(&non_existing_file)).unwrap_err();
 }
 
 #[test]
@@ -275,9 +260,7 @@ fn test_read_canister_ids_from_file() {
     write!(canister_ids_file, "{}", json_str).expect("Cannot write to tmp file");
 
     let actual_canister_ids =
-        read_sns_canister_ids(Some(canister_ids_file.path().to_str().unwrap().to_string()))
-            .expect("Unable to read canister_ids_file")
-            .expect("None returned instead of Some");
+        read_sns_canister_ids(canister_ids_file.path()).expect("Unable to read canister_ids_file");
 
     assert_eq!(actual_canister_ids, expected_canister_ids);
 }
@@ -301,9 +284,7 @@ fn test_read_canister_ids_from_file_empty_dapp_canister_id_list() {
     write!(canister_ids_file, "{}", json_str).expect("Cannot write to tmp file");
 
     let actual_canister_ids =
-        read_sns_canister_ids(Some(canister_ids_file.path().to_str().unwrap().to_string()))
-            .expect("Unable to read canister_ids_file")
-            .expect("None returned instead of Some");
+        read_sns_canister_ids(canister_ids_file.path()).expect("Unable to read canister_ids_file");
 
     assert_eq!(actual_canister_ids, expected_canister_ids);
 }
@@ -311,15 +292,9 @@ fn test_read_canister_ids_from_file_empty_dapp_canister_id_list() {
 #[test]
 fn test_canister_ids_from_non_existing_file() {
     let dir = tempfile::tempdir().expect("Cannot create temp dir");
-    let non_existing_file = dir
-        .path()
-        .join("non_existing_pem_file")
-        .as_path()
-        .to_str()
-        .unwrap()
-        .to_string();
+    let non_existing_file = dir.path().join("non_existing_pem_file");
 
-    read_sns_canister_ids(Some(non_existing_file)).unwrap_err();
+    read_sns_canister_ids(&non_existing_file).unwrap_err();
 }
 
 #[test]
@@ -331,8 +306,7 @@ fn test_canister_ids_from_malformed_canister_id() {
     let raw_json = r#"{"governance_canister_id": "Not a valid canister id","ledger_canister_id": "Not a valid canister id","root_canister_id": "Not a valid canister id"}"#;
     write!(canister_ids_file, "{}", raw_json).expect("Cannot write to tmp file");
 
-    read_sns_canister_ids(Some(canister_ids_file.path().to_str().unwrap().to_string()))
-        .unwrap_err();
+    read_sns_canister_ids(canister_ids_file.path()).unwrap_err();
 }
 
 #[test]
@@ -344,6 +318,5 @@ fn test_canister_ids_from_missing_key() {
     let raw_json = r#"{"ledger_canister_id": "Not a valid canister id","root_canister_id": "Not a valid canister id"}"#;
     write!(canister_ids_file, "{}", raw_json).expect("Cannot write to tmp file");
 
-    read_sns_canister_ids(Some(canister_ids_file.path().to_str().unwrap().to_string()))
-        .unwrap_err();
+    read_sns_canister_ids(canister_ids_file.path()).unwrap_err();
 }

--- a/tests/commands/account-balance.sh
+++ b/tests/commands/account-balance.sh
@@ -1,2 +1,2 @@
 LEDGER_ACCOUNT_ID=ec0e2456fb9ff6c80f1d475b301d9b2ab873612f96e7fd74e7c0c0b2d58e6693
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json  account-balance $LEDGER_ACCOUNT_ID --dry-run
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill account-balance $LEDGER_ACCOUNT_ID --dry-run --canister-ids-file ./canister_ids.json

--- a/tests/commands/configure-dissolve-delay-add-seconds.sh
+++ b/tests/commands/configure-dissolve-delay-add-seconds.sh
@@ -1,2 +1,2 @@
 NEURON_ID=83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - configure-dissolve-delay $NEURON_ID --additional-dissolve-delay-seconds 1000 | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill configure-dissolve-delay $NEURON_ID --additional-dissolve-delay-seconds 1000 --canister-ids-file ./canister_ids.json --pem-file - | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -

--- a/tests/commands/configure-dissolve-delay-start-dissolving.sh
+++ b/tests/commands/configure-dissolve-delay-start-dissolving.sh
@@ -1,2 +1,2 @@
 NEURON_ID=83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - configure-dissolve-delay $NEURON_ID --start-dissolving | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill configure-dissolve-delay $NEURON_ID --start-dissolving --canister-ids-file ./canister_ids.json --pem-file - | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -

--- a/tests/commands/configure-dissolve-delay-stop-dissolving.sh
+++ b/tests/commands/configure-dissolve-delay-stop-dissolving.sh
@@ -1,2 +1,2 @@
 NEURON_ID=83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - configure-dissolve-delay $NEURON_ID --stop-dissolving | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill configure-dissolve-delay $NEURON_ID --stop-dissolving --canister-ids-file ./canister_ids.json --pem-file - | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -

--- a/tests/commands/fixed-pipe.sh
+++ b/tests/commands/fixed-pipe.sh
@@ -1,2 +1,2 @@
 LEDGER_ACCOUNT_ID=345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - transfer $LEDGER_ACCOUNT_ID --amount 123.0456 | gzip --best --to-stdout | zcat | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill transfer $LEDGER_ACCOUNT_ID --amount 123.0456 --canister-ids-file ./canister_ids.json --pem-file - | gzip --best --to-stdout | zcat | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -

--- a/tests/commands/list-deployed-snses.sh
+++ b/tests/commands/list-deployed-snses.sh
@@ -1,1 +1,1 @@
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json list-deployed-snses --dry-run
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill list-deployed-snses --dry-run

--- a/tests/commands/make-proposal.sh
+++ b/tests/commands/make-proposal.sh
@@ -1,4 +1,4 @@
 NEURON_ID=83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
 PROPOSAL='( record { title="SNS Launch"; url="https://dfinity.org"; summary="A motion to start the SNS"; action=opt variant { Motion=record { motion_text="I hereby raise the motion that the use of the SNS shall commence"; } }; } )'
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - make-proposal $NEURON_ID --proposal "${PROPOSAL}" | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill make-proposal $NEURON_ID --proposal "${PROPOSAL}" --canister-ids-file ./canister_ids.json --pem-file - | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
 

--- a/tests/commands/make-upgrade-canister-proposal.sh
+++ b/tests/commands/make-upgrade-canister-proposal.sh
@@ -1,12 +1,12 @@
 PROPOSER_NEURON_ID=83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
 
 ${CARGO_TARGET_DIR:-../target}/debug/sns-quill \
-                              --canister-ids-file=./canister_ids.json \
-                              --pem-file=- \
                               make-upgrade-canister-proposal \
                               --wasm-path=outputs/canister.wasm \
                               --target-canister-id=pycv5-3jbbb-ccccc-ddddd-cai \
                               $PROPOSER_NEURON_ID \
+                              --canister-ids-file=./canister_ids.json \
+                              --pem-file=- \
     | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill \
                                     send \
                                     --dry-run \

--- a/tests/commands/neuron-permission-add.sh
+++ b/tests/commands/neuron-permission-add.sh
@@ -1,2 +1,2 @@
 NEURON_ID=83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - neuron-permission add $NEURON_ID --principal fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae --permissions submit-proposal,vote | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill neuron-permission add $NEURON_ID --principal fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae --permissions submit-proposal,vote --canister-ids-file ./canister_ids.json --pem-file - | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -

--- a/tests/commands/neuron-permission-remove.sh
+++ b/tests/commands/neuron-permission-remove.sh
@@ -1,2 +1,2 @@
 NEURON_ID=83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - neuron-permission remove $NEURON_ID --principal fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae --permissions merge-maturity disburse-maturity | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill neuron-permission remove $NEURON_ID --principal fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae --permissions merge-maturity disburse-maturity --canister-ids-file ./canister_ids.json --pem-file - | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -

--- a/tests/commands/neuron-stake-memo.sh
+++ b/tests/commands/neuron-stake-memo.sh
@@ -1,1 +1,1 @@
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - stake-neuron --amount 12 --memo 777 | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill stake-neuron --amount 12 --memo 777 --canister-ids-file ./canister_ids.json --pem-file - | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -

--- a/tests/commands/neuron-stake-no-amount.sh
+++ b/tests/commands/neuron-stake-no-amount.sh
@@ -1,1 +1,1 @@
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - stake-neuron --memo 777 | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill stake-neuron --memo 777 --canister-ids-file ./canister_ids.json --pem-file - | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -

--- a/tests/commands/public-ids.sh
+++ b/tests/commands/public-ids.sh
@@ -1,2 +1,2 @@
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --pem-file - public-ids
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill public-ids --pem-file -
 ${CARGO_TARGET_DIR:-../target}/debug/sns-quill public-ids --principal-id 44mwt-bq3um-tqicz-bwhad-iipx4-6wzex-olvaj-z63bj-wkelv-xoua3-rqe

--- a/tests/commands/refund.sh
+++ b/tests/commands/refund.sh
@@ -1,1 +1,1 @@
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - get-swap-refund --amount 500 | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill get-swap-refund --amount 500 --canister-ids-file ./canister_ids.json --pem-file - | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -

--- a/tests/commands/register-vote-no.sh
+++ b/tests/commands/register-vote-no.sh
@@ -1,3 +1,3 @@
 NEURON_ID=83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - register-vote $NEURON_ID --proposal-id 1 --vote n | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill register-vote $NEURON_ID --proposal-id 1 --vote n --canister-ids-file ./canister_ids.json --pem-file - | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
 

--- a/tests/commands/register-vote-yes.sh
+++ b/tests/commands/register-vote-yes.sh
@@ -1,3 +1,3 @@
 NEURON_ID=83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - register-vote $NEURON_ID --proposal-id 1 --vote y | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill register-vote $NEURON_ID --proposal-id 1 --vote y --canister-ids-file ./canister_ids.json --pem-file - | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
 

--- a/tests/commands/status.sh
+++ b/tests/commands/status.sh
@@ -1,1 +1,1 @@
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json status --dry-run
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill status --dry-run --canister-ids-file ./canister_ids.json

--- a/tests/commands/swap.sh
+++ b/tests/commands/swap.sh
@@ -1,1 +1,1 @@
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - swap --amount 500 --memo 4 | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill swap --amount 500 --memo 4 --canister-ids-file ./canister_ids.json --pem-file - | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -

--- a/tests/commands/transfer-e8s-2.sh
+++ b/tests/commands/transfer-e8s-2.sh
@@ -1,2 +1,2 @@
 LEDGER_ACCOUNT_ID=345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - transfer $LEDGER_ACCOUNT_ID --amount 0.0000000999999 | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill transfer $LEDGER_ACCOUNT_ID --amount 0.0000000999999 --canister-ids-file ./canister_ids.json --pem-file - | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -

--- a/tests/commands/transfer-e8s.sh
+++ b/tests/commands/transfer-e8s.sh
@@ -1,2 +1,2 @@
 LEDGER_ACCOUNT_ID=345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - transfer $LEDGER_ACCOUNT_ID --amount 0.123456 | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill transfer $LEDGER_ACCOUNT_ID --amount 0.123456 --canister-ids-file ./canister_ids.json --pem-file - | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -

--- a/tests/commands/transfer-token-and-e8s.sh
+++ b/tests/commands/transfer-token-and-e8s.sh
@@ -1,2 +1,2 @@
 LEDGER_ACCOUNT_ID=345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - transfer $LEDGER_ACCOUNT_ID --amount 1.23456 | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill transfer $LEDGER_ACCOUNT_ID --amount 1.23456 --canister-ids-file ./canister_ids.json --pem-file - | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -

--- a/tests/commands/transfer-with-fees-and-memo.sh
+++ b/tests/commands/transfer-with-fees-and-memo.sh
@@ -1,2 +1,2 @@
 LEDGER_ACCOUNT_ID=345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - transfer $LEDGER_ACCOUNT_ID --amount 123.0456 --fee 0.0023 --memo 777 | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill transfer $LEDGER_ACCOUNT_ID --amount 123.0456 --fee 0.0023 --memo 777 --canister-ids-file ./canister_ids.json --pem-file - | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -

--- a/tests/commands/transfer-with-fees.sh
+++ b/tests/commands/transfer-with-fees.sh
@@ -1,2 +1,2 @@
 LEDGER_ACCOUNT_ID=345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - transfer $LEDGER_ACCOUNT_ID --amount 123.0456 --fee 0.0023 | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill transfer $LEDGER_ACCOUNT_ID --amount 123.0456 --fee 0.0023 --canister-ids-file ./canister_ids.json --pem-file - | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -

--- a/tests/commands/transfer.sh
+++ b/tests/commands/transfer.sh
@@ -1,2 +1,2 @@
 LEDGER_ACCOUNT_ID=345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752
-${CARGO_TARGET_DIR:-../target}/debug/sns-quill --canister-ids-file ./canister_ids.json --pem-file - transfer $LEDGER_ACCOUNT_ID --amount 0.000123 | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/sns-quill transfer $LEDGER_ACCOUNT_ID --amount 0.000123 --canister-ids-file ./canister_ids.json --pem-file - | ${CARGO_TARGET_DIR:-../target}/debug/sns-quill send --dry-run -


### PR DESCRIPTION
This PR follows an equivalent change to `quill` - in line with how a traditional CLI tool works, all the arguments have been moved to the end of the command. So instead of `sns-quill --pem-file - public-ids`, it becomes `sns-quill public-ids --pem-file -`. This also means the arguments correctly display when they're applicable in help messages. As this required a little bit of rearchitecting, I've taken the opportunity to clean up various other things.