### PR TITLE
feat: encrypted identities by default

### DIFF
--- a/src/commands/configure_dissolve_delay.rs
+++ b/src/commands/configure_dissolve_delay.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     lib::{
         parse_neuron_id,
@@ -9,6 +11,7 @@ use crate::{
 use anyhow::{anyhow, Error};
 use candid::Encode;
 use clap::Parser;
+use ic_agent::Identity;
 use ic_base_types::PrincipalId;
 
 use ic_sns_governance::pb::v1::{
@@ -50,7 +53,7 @@ pub struct ConfigureDissolveDelayOpts {
 }
 
 pub fn exec(
-    private_key_pem: &str,
+    ident: Arc<dyn Identity>,
     sns_canister_ids: &SnsCanisterIds,
     opts: ConfigureDissolveDelayOpts,
 ) -> AnyhowResult<Vec<IngressWithRequestId>> {
@@ -100,7 +103,7 @@ pub fn exec(
     };
 
     let msg = sign_ingress_with_request_status_query(
-        private_key_pem,
+        ident,
         "manage_neuron",
         args,
         TargetCanister::Governance(governance_canister_id),

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1,9 +1,14 @@
 use crate::lib::{mnemonic_to_pem, AnyhowResult};
-use anyhow::{anyhow, Context};
+use anyhow::{bail, Context};
 use bip39::{Language, Mnemonic};
 use clap::Parser;
+use dialoguer::Password;
 use rand::{rngs::OsRng, RngCore};
-use std::path::Path;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 #[derive(Parser, Debug)]
 #[clap(about, version, author)]
@@ -13,59 +18,101 @@ pub struct GenerateOpts {
     words: u32,
 
     /// File to write the seed phrase to.
-    #[clap(long, default_value = "seed.txt")]
-    seed_file: String,
+    #[clap(long)]
+    out_seed_file: Option<PathBuf>,
 
     /// File to write the PEM to.
-    #[clap(long)]
-    pem_file: Option<String>,
+    #[clap(long, default_value("identity.pem"))]
+    to_pem_file: PathBuf,
 
-    /// A seed phrase in quotes to use to generate the PEM file.
     #[clap(long)]
-    phrase: Option<String>,
+    pem_file: Option<Dummy>, // fake param to ensure it is not accidentally used instead of --to-pem-file
+
+    /// A file containing a seed phrase to generate the key from.
+    #[clap(long, conflicts_with("out-seed-file"))]
+    from_seed_file: Option<PathBuf>,
 
     /// Overwrite any existing seed file.
-    #[clap(long)]
+    #[clap(long, requires("out-seed-file"))]
     overwrite_seed_file: bool,
 
     /// Overwrite any existing PEM file.
     #[clap(long)]
     overwrite_pem_file: bool,
+
+    /// Disable PEM encryption.
+    #[clap(long)]
+    disable_encryption: bool,
+}
+
+#[derive(Debug)]
+struct Dummy;
+
+impl FromStr for Dummy {
+    type Err = &'static str;
+    fn from_str(_: &str) -> Result<Self, Self::Err> {
+        Err("--pem-file is incorrect for this command (did you mean --to-pem-file?)")
+    }
 }
 
 /// Generate or recover mnemonic seed phrase and/or PEM file.
 pub fn exec(opts: GenerateOpts) -> AnyhowResult {
-    if Path::new(&opts.seed_file).exists() && !opts.overwrite_seed_file {
-        return Err(anyhow!("Seed file exists and overwrite is not set."));
-    }
-    if let Some(path) = &opts.pem_file {
-        if Path::new(path).exists() && !opts.overwrite_pem_file {
-            return Err(anyhow!("PEM file exists and overwrite is not set."));
-        }
+    if !opts.overwrite_pem_file && opts.to_pem_file.exists() {
+        bail!("PEM file exists and overwrite is not set.");
     }
     let bytes = match opts.words {
         12 => 16,
         24 => 32,
-        _ => return Err(anyhow!("Words must be 12 or 24.")),
+        _ => bail!("Words must be 12 or 24."),
     };
-    let mnemonic = match opts.phrase {
-        Some(phrase) => Mnemonic::parse(phrase).context("Failed to parse mnemonic")?,
+    let mnemonic = match &opts.from_seed_file {
+        Some(phrase_file) => {
+            Mnemonic::parse(fs::read_to_string(phrase_file)?).context("Failed to parse mnemonic")?
+        }
         None => {
             let mut key = vec![0u8; bytes];
             OsRng.fill_bytes(&mut key);
             Mnemonic::from_entropy_in(Language::English, &key).unwrap()
         }
     };
-    let pem = mnemonic_to_pem(&mnemonic, None).context("Failed to convert mnemonic to PEM")?;
+    let password = (!opts.disable_encryption)
+        .then(|| {
+            Password::new()
+                .with_prompt("Enter a password to encrypt the PEM")
+                .with_confirmation(
+                    "Re-enter the password to confirm",
+                    "Passwords did not match",
+                )
+                .interact()
+        })
+        .transpose()?;
+    // argon2 is not needed, the algorithm already uses scrypt
+    let pem = mnemonic_to_pem(&mnemonic, password.as_ref().map(|s| s.as_bytes()))
+        .context("Failed to convert mnemonic to PEM")?;
     let mut phrase = mnemonic
         .word_iter()
         .collect::<Vec<&'static str>>()
         .join(" ");
     phrase.push('\n');
-    std::fs::write(opts.seed_file, phrase)?;
-    if let Some(path) = opts.pem_file {
-        std::fs::write(path, pem.clone())?;
+    match opts.out_seed_file {
+        Some(file) if file != Path::new("-") => {
+            if !opts.overwrite_seed_file && file.exists() {
+                bail!("Seed file exists and overwrite is not set.")
+            }
+            fs::write(file, phrase)?;
+        }
+        _ => {
+            if opts.from_seed_file.is_none() {
+                eprintln!("Your seed phrase: {phrase}\nThis can be used to reconstruct your key in case of emergency, so write it down and store it in a safe place.")
+            }
+        }
     }
+    if opts.to_pem_file == Path::new("-") {
+        println!("{pem}");
+    } else {
+        fs::write(opts.to_pem_file, &pem)?;
+    }
+    // skip get_ids to skip decrypting it again
     let (principal_id, account_id) = crate::commands::public::get_ids(&Some(pem))?;
     println!("Principal id: {}", principal_id);
     println!("NNS account id: {}", account_id);

--- a/src/commands/get_swap_refund.rs
+++ b/src/commands/get_swap_refund.rs
@@ -1,5 +1,8 @@
+use std::sync::Arc;
+
 use candid::Encode;
 use clap::Parser;
+use ic_agent::Identity;
 use ic_sns_swap::pb::v1::ErrorRefundIcpRequest;
 
 use crate::{
@@ -26,7 +29,7 @@ pub struct GetSwapRefundOpts {
 }
 
 pub fn exec(
-    pem: &str,
+    ident: Arc<dyn Identity>,
     sns_canister_ids: &SnsCanisterIds,
     opts: GetSwapRefundOpts,
 ) -> AnyhowResult<Vec<IngressWithRequestId>> {
@@ -41,7 +44,7 @@ pub fn exec(
         fee_override_e8s: fee,
     };
     let req = sign_ingress_with_request_status_query(
-        pem,
+        ident,
         "error_refund_icp",
         Encode!(&message)?,
         TargetCanister::Swap(sns_canister_ids.swap_canister_id.get().0),

--- a/src/commands/make_proposal.rs
+++ b/src/commands/make_proposal.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     lib::{
         parse_neuron_id,
@@ -9,6 +11,7 @@ use crate::{
 use anyhow::Error;
 use candid::{Decode, Encode, IDLArgs};
 use clap::Parser;
+use ic_agent::Identity;
 use ic_sns_governance::pb::v1::{manage_neuron, ManageNeuron, Proposal};
 
 /// Signs a ManageNeuron message to submit a proposal. With this command, neuron holders
@@ -41,7 +44,7 @@ pub struct MakeProposalOpts {
 }
 
 pub fn exec(
-    private_key_pem: &str,
+    ident: Arc<dyn Identity>,
     sns_canister_ids: &SnsCanisterIds,
     opts: MakeProposalOpts,
 ) -> AnyhowResult<Vec<IngressWithRequestId>> {
@@ -57,7 +60,7 @@ pub fn exec(
     })?;
 
     let msg = sign_ingress_with_request_status_query(
-        private_key_pem,
+        ident,
         "manage_neuron",
         args,
         TargetCanister::Governance(governance_canister_id),

--- a/src/commands/make_upgrade_canister_proposal.rs
+++ b/src/commands/make_upgrade_canister_proposal.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     lib::{
         parse_neuron_id,
@@ -9,6 +11,7 @@ use crate::{
 use anyhow::{Context, Error};
 use candid::Encode;
 use clap::Parser;
+use ic_agent::Identity;
 use ic_base_types::PrincipalId;
 use ic_sns_governance::pb::v1::{
     manage_neuron, proposal, ManageNeuron, Proposal, UpgradeSnsControlledCanister,
@@ -47,7 +50,7 @@ pub struct MakeUpgradeCanisterProposalOpts {
 }
 
 pub fn exec(
-    private_key_pem: &str,
+    ident: Arc<dyn Identity>,
     sns_canister_ids: &SnsCanisterIds,
     opts: MakeUpgradeCanisterProposalOpts,
 ) -> AnyhowResult<Vec<IngressWithRequestId>> {
@@ -92,7 +95,7 @@ pub fn exec(
     })?;
 
     let msg = sign_ingress_with_request_status_query(
-        private_key_pem,
+        ident,
         "manage_neuron",
         args,
         TargetCanister::Governance(governance_canister_id),

--- a/src/commands/make_upgrade_canister_proposal.rs
+++ b/src/commands/make_upgrade_canister_proposal.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use crate::{
     lib::{
@@ -46,7 +46,7 @@ pub struct MakeUpgradeCanisterProposalOpts {
 
     /// Path to the WASM file to be installed onto the target canister.
     #[clap(long)]
-    wasm_path: String,
+    wasm_path: PathBuf,
 }
 
 pub fn exec(

--- a/src/commands/neuron_permission.rs
+++ b/src/commands/neuron_permission.rs
@@ -1,6 +1,9 @@
+use std::sync::Arc;
+
 use anyhow::anyhow;
 use candid::Encode;
 use clap::{ArgEnum, Parser};
+use ic_agent::Identity;
 use ic_base_types::PrincipalId;
 use ic_sns_governance::pb::v1::{
     manage_neuron::{AddNeuronPermissions, Command, RemoveNeuronPermissions},
@@ -48,7 +51,7 @@ enum Subcmd {
 }
 
 pub fn exec(
-    pem: &str,
+    ident: Arc<dyn Identity>,
     canister_ids: &SnsCanisterIds,
     opts: NeuronPermissionOpts,
 ) -> AnyhowResult<Vec<IngressWithRequestId>> {
@@ -72,7 +75,7 @@ pub fn exec(
         }),
     };
     let msg = sign_ingress_with_request_status_query(
-        pem,
+        ident,
         "manage_neuron",
         Encode!(&req)?,
         TargetCanister::Governance(canister_ids.governance_canister_id.get().0),

--- a/src/commands/public.rs
+++ b/src/commands/public.rs
@@ -1,6 +1,9 @@
-use crate::lib::{get_account_id, get_identity, require_pem, AnyhowResult};
+use std::sync::Arc;
+
+use crate::lib::{get_account_id, require_identity, AnyhowResult};
 use anyhow::anyhow;
 use clap::Parser;
+use ic_agent::Identity;
 use ic_types::principal::Principal;
 use ledger_canister::AccountIdentifier;
 
@@ -12,8 +15,8 @@ pub struct PublicOpts {
 }
 
 /// Prints the account and the principal ids.
-pub fn exec(pem: &Option<String>, opts: PublicOpts) -> AnyhowResult {
-    let (principal_id, account_id) = get_public_ids(pem, opts)?;
+pub fn exec(ident: Option<Arc<dyn Identity>>, opts: PublicOpts) -> AnyhowResult {
+    let (principal_id, account_id) = get_public_ids(ident, opts)?;
     println!("Principal id: {}", principal_id.to_text());
     println!("NNS account id: {}", account_id);
     Ok(())
@@ -21,7 +24,7 @@ pub fn exec(pem: &Option<String>, opts: PublicOpts) -> AnyhowResult {
 
 /// Returns the account id and the principal id if the private key was provided.
 fn get_public_ids(
-    pem: &Option<String>,
+    ident: Option<Arc<dyn Identity>>,
     opts: PublicOpts,
 ) -> AnyhowResult<(Principal, AccountIdentifier)> {
     match opts.principal_id {
@@ -29,13 +32,13 @@ fn get_public_ids(
             let principal_id = ic_types::Principal::from_text(principal_id)?;
             Ok((principal_id, get_account_id(principal_id)?))
         }
-        None => get_ids(pem),
+        None => get_ids(ident),
     }
 }
 
 /// Returns the account id and the principal id if the private key was provided.
-pub fn get_ids(pem: &Option<String>) -> AnyhowResult<(Principal, AccountIdentifier)> {
-    let pem = require_pem(pem)?;
-    let principal_id = get_identity(&pem)?.sender().map_err(|e| anyhow!(e))?;
+pub fn get_ids(ident: Option<Arc<dyn Identity>>) -> AnyhowResult<(Principal, AccountIdentifier)> {
+    let ident = require_identity(ident)?;
+    let principal_id = ident.sender().map_err(|e| anyhow!(e))?;
     Ok((principal_id, get_account_id(principal_id)?))
 }

--- a/src/commands/qrcode.rs
+++ b/src/commands/qrcode.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use crate::lib::{qr::print_qr, read_from_file, AnyhowResult};
 use clap::Parser;
 
@@ -5,7 +7,7 @@ use clap::Parser;
 pub struct QRCodeOpts {
     /// File the contents of which to be output as a QRCode.
     #[clap(long)]
-    file: Option<String>,
+    file: Option<PathBuf>,
 
     // String to be output as a QRCode.
     #[clap(long)]

--- a/src/commands/register_vote.rs
+++ b/src/commands/register_vote.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     lib::{
         parse_neuron_id,
@@ -9,6 +11,7 @@ use crate::{
 use anyhow::{anyhow, Error};
 use candid::Encode;
 use clap::Parser;
+use ic_agent::Identity;
 use ic_sns_governance::pb::v1::{
     manage_neuron, manage_neuron::RegisterVote, ManageNeuron, ProposalId, Vote,
 };
@@ -33,7 +36,7 @@ pub struct RegisterVoteOpts {
 }
 
 pub fn exec(
-    private_key_pem: &str,
+    ident: Arc<dyn Identity>,
     sns_canister_ids: &SnsCanisterIds,
     opts: RegisterVoteOpts,
 ) -> AnyhowResult<Vec<IngressWithRequestId>> {
@@ -60,7 +63,7 @@ pub fn exec(
     })?;
 
     let msg = sign_ingress_with_request_status_query(
-        private_key_pem,
+        ident,
         "manage_neuron",
         args,
         TargetCanister::Governance(governance_canister_id),

--- a/src/commands/request_status.rs
+++ b/src/commands/request_status.rs
@@ -2,6 +2,7 @@ use crate::lib::{get_agent, get_ic_url, signing::RequestStatus, AnyhowResult};
 use anyhow::{anyhow, Context};
 use ic_agent::{
     agent::{ReplicaV2Transport, Replied, RequestStatusResponse},
+    identity::AnonymousIdentity,
     Agent, AgentError,
     AgentError::MessageError,
     RequestId,
@@ -13,7 +14,7 @@ pub async fn submit(req: &RequestStatus) -> AnyhowResult<Vec<u8>> {
     let canister_id =
         Principal::from_text(&req.canister_id).context("Cannot parse the canister id")?;
     let request_id = RequestId::from_str(&req.request_id).context("Cannot parse the request_id")?;
-    let mut agent = get_agent("")?;
+    let mut agent = get_agent(Arc::new(AnonymousIdentity))?;
     update_agent_root_key(&mut agent).await?;
     agent.set_transport(ProxySignReplicaV2Transport {
         req: req.clone(),

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -11,12 +11,13 @@ use candid::{Decode, Nat};
 use clap::Parser;
 use ic_agent::{
     agent::{http_transport::ReqwestHttpReplicaV2Transport, ReplicaV2Transport},
+    identity::AnonymousIdentity,
     RequestId,
 };
 use ic_icrc1::endpoints::TransferError;
 use ic_ledger_core::Tokens;
 use ic_sns_governance::pb::v1::ManageNeuronResponse;
-use std::{path::PathBuf, str::FromStr};
+use std::{path::PathBuf, str::FromStr, sync::Arc};
 
 /// Sends a signed message or a set of messages.
 #[derive(Parser)]
@@ -58,7 +59,7 @@ pub async fn send_unsigned_ingress(
     target_canister: TargetCanister,
 ) -> AnyhowResult {
     let msg = crate::lib::signing::sign_ingress_with_request_status_query(
-        "",
+        Arc::new(AnonymousIdentity),
         method_name,
         args,
         target_canister,

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -16,13 +16,13 @@ use ic_agent::{
 use ic_icrc1::endpoints::TransferError;
 use ic_ledger_core::Tokens;
 use ic_sns_governance::pb::v1::ManageNeuronResponse;
-use std::str::FromStr;
+use std::{path::PathBuf, str::FromStr};
 
 /// Sends a signed message or a set of messages.
 #[derive(Parser)]
 pub struct SendOpts {
     /// Path to the signed message. Use "-" for STDIN.
-    file_name: String,
+    file_name: PathBuf,
 
     /// Will display the signed message, but not send it.
     #[clap(long)]

--- a/src/commands/transfer.rs
+++ b/src/commands/transfer.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{str::FromStr, sync::Arc};
 
 use crate::{
     lib::{
@@ -10,6 +10,7 @@ use crate::{
 use anyhow::{anyhow, bail, ensure, Context};
 use candid::Encode;
 use clap::Parser;
+use ic_agent::Identity;
 use ic_base_types::PrincipalId;
 use ic_icrc1::{endpoints::TransferArg, Subaccount};
 use ic_ledger_core::Tokens;
@@ -40,7 +41,7 @@ pub struct TransferOpts {
 }
 
 pub fn exec(
-    private_key_pem: &str,
+    ident: Arc<dyn Identity>,
     sns_canister_ids: &SnsCanisterIds,
     opts: TransferOpts,
 ) -> AnyhowResult<Vec<IngressWithRequestId>> {
@@ -79,7 +80,7 @@ pub fn exec(
     };
 
     let msg = sign_ingress_with_request_status_query(
-        private_key_pem,
+        ident,
         "icrc1_transfer",
         Encode!(&args)?,
         TargetCanister::Ledger(ledger_canister_id),

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,5 +1,5 @@
 //! All the common functionality.
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 
 use crate::SnsCanisterIds;
 use anyhow::{anyhow, Context};
@@ -119,7 +119,7 @@ pub fn read_from_file(path: &Path) -> AnyhowResult<String> {
 }
 
 /// Returns an agent with an identity derived from a private key if it was provided.
-pub fn get_agent(pem: &str) -> AnyhowResult<Agent> {
+pub fn get_agent(ident: Arc<dyn Identity>) -> AnyhowResult<Agent> {
     let timeout = std::time::Duration::from_secs(60 * 5);
     let builder = Agent::builder()
         .with_transport(
@@ -128,12 +128,11 @@ pub fn get_agent(pem: &str) -> AnyhowResult<Agent> {
             })?,
         )
         .with_ingress_expiry(Some(timeout));
-
-    Ok(builder.with_boxed_identity(get_identity(pem)?).build()?)
+    Ok(builder.with_arc_identity(ident).build()?)
 }
 
 /// Returns an identity derived from the private key.
-pub fn get_identity(pem: &str) -> AnyhowResult<Box<dyn Identity + Sync + Send>> {
+pub fn get_identity(pem: &str, password: Option<&[u8]>) -> AnyhowResult<Arc<dyn Identity>> {
     fn is_encrypted_err(pk_error: pkcs8::Error) -> bool {
         use pkcs8::{
             der::{pem::Error as PemError, ErrorKind as DerError},
@@ -153,38 +152,39 @@ pub fn get_identity(pem: &str) -> AnyhowResult<Box<dyn Identity + Sync + Send>> 
         }
     }
     if pem.is_empty() {
-        return Ok(Box::new(AnonymousIdentity));
+        return Ok(Arc::new(AnonymousIdentity));
     }
     // pkcs8?
     Ok(match SecretKey::from_pkcs8_pem(pem) {
-        Ok(key) => Box::new(Secp256k1Identity::from_private_key(key)),
+        Ok(key) => Arc::new(Secp256k1Identity::from_private_key(key)),
         Err(pk_error) if is_encrypted_err(pk_error) => {
-            let password = Password::new()
-                .with_prompt("PEM decryption password")
-                .interact()?;
-            Box::new(Secp256k1Identity::from_private_key(
+            let pass_string;
+            let password = if let Some(pass) = password {
+                pass
+            } else {
+                pass_string = Password::new()
+                    .with_prompt("PEM decryption password")
+                    .interact()?;
+                pass_string.as_bytes()
+            };
+            Arc::new(Secp256k1Identity::from_private_key(
                 SecretKey::from_pkcs8_encrypted_pem(pem, password)?,
             ))
         }
         // sec1?
         Err(e) => match Secp256k1Identity::from_pem(pem.as_bytes()) {
-            Ok(ident) => Box::new(ident),
+            Ok(ident) => Arc::new(ident),
             // ed25519?
             Err(_) => match BasicIdentity::from_pem(pem.as_bytes()) {
-                Ok(ident) => Box::new(ident),
+                Ok(ident) => Arc::new(ident),
                 Err(_) => return Err(e).context("Couldn't load identity from PEM file"),
             },
         },
     })
 }
 
-pub fn require_pem(pem: &Option<String>) -> AnyhowResult<String> {
-    match pem {
-        None => Err(anyhow!(
-            "Cannot use anonymous principal, did you forget --pem-file <pem-file> ?"
-        )),
-        Some(val) => Ok(val.clone()),
-    }
+pub fn require_identity(ident: Option<Arc<dyn Identity>>) -> AnyhowResult<Arc<dyn Identity>> {
+    ident.context("Cannot use anonymous principal, did you forget --pem-file <pem-file> ?")
 }
 
 pub fn require_canister_ids(

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,7 +216,7 @@ fn test_read_pem_from_non_existing_file() {
         .unwrap()
         .to_string();
 
-    read_pem(Some(non_existing_file.clone())).unwrap_err();
+    read_pem(Some(non_existing_file)).unwrap_err();
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use crate::lib::AnyhowResult;
 use anyhow::{anyhow, Context};
 use clap::{crate_version, Parser};
 use ic_base_types::CanisterId;
+use lib::get_identity;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::HashMap, fs::File, path::PathBuf, str::FromStr};
@@ -70,8 +71,9 @@ fn main() {
 
 fn run(opts: CliOpts) -> AnyhowResult<()> {
     let pem = read_pem(opts.pem_file)?;
+    let identity = pem.map(|pem| get_identity(&pem, None)).transpose()?;
     let canister_ids = read_sns_canister_ids(opts.canister_ids_file)?;
-    commands::exec(&pem, &canister_ids, opts.qr, opts.command)
+    commands::exec(identity, &canister_ids, opts.qr, opts.command)
 }
 
 /// Get PEM from the file if provided, or try to convert from the seed file


### PR DESCRIPTION
Per FOLLOW-728, quill currently stores sensitive data to disk as plaintext. This PR makes identities password-protected by default, using pkcs8's built-in scrypt encryption mechanism. It additionally stops storing seed phrases in txt files unless the user explicitly requests it, stops using seed phrases as a primary key at all, overhauls the internal representation of keys to be ic-agent identities instead of pem files (to facilitate only decrypting once per command) and fixes a few other things I found along the way like file paths being stored as strings.