### PR TITLE
Fix .github/workflows/release.yml to generate a downloadable release for sns-quill

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,13 @@ jobs:
             target_file: target/release/sns-quill
             asset_name: sns-quill-macos-x86_64
             make_target: release
-            rust: stable
+            rust: 1.64.0
           - os: ubuntu-latest
             name: arm
             target_file: target/arm-unknown-linux-gnueabihf/release/sns-quill
             asset_name: sns-quill-arm_32
             make_target: unused
-            rust: stable
+            rust: 1.64.0
     steps:
     - uses: actions/checkout@master
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,25 +15,25 @@ jobs:
         include:
           - os: ubuntu-latest
             name: linux
-            target_file: target/x86_64-unknown-linux-musl/release/quill
-            asset_name: quill-linux-x86_64
+            target_file: target/x86_64-unknown-linux-musl/release/sns-quill
+            asset_name: sns-quill-linux-x86_64
             make_target: musl-static
           - os: windows-latest
             name: windows
-            target_file: target/release/quill.exe
-            asset_name: quill-windows-x86_64.exe
+            target_file: target/release/sns-quill.exe
+            asset_name: sns-quill-windows-x86_64.exe
             make_target: release
             rust: 1.64.0
           - os: macos-latest
             name: macos
-            target_file: target/release/quill
-            asset_name: quill-macos-x86_64
+            target_file: target/release/sns-quill
+            asset_name: sns-quill-macos-x86_64
             make_target: release
             rust: stable
           - os: ubuntu-latest
             name: arm
-            target_file: target/arm-unknown-linux-gnueabihf/release/quill
-            asset_name: quill-arm_32
+            target_file: target/arm-unknown-linux-gnueabihf/release/sns-quill
+            asset_name: sns-quill-arm_32
             make_target: unused
             rust: stable
     steps:
@@ -52,7 +52,7 @@ jobs:
 
     - name: Install toolchain (Linux static)
       if: matrix.name == 'linux'
-      uses: gmiam/rust-musl-action@master
+      uses: mariodfinity/rust-musl-action@master
       with:
         args: make ${{ matrix.make_target }}
     - name: Install toolchain (ARM)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sns-quill"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["DFINITY Team"]
 edition = "2018"
 


### PR DESCRIPTION
Releases seem to have been failing due to one of the dependencies used in the release job. I've updated that dependency, named the executable correctly, and bumped the cargo version to match the release version.