### PR TITLE
Updating Cargo.lock with the new version so CI will work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4124,7 +4124,7 @@ checksum = "cc88c725d61fc6c3132893370cac4a0200e3fedf5da8331c570664b1987f5ca2"
 
 [[package]]
 name = "sns-quill"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/candid/governance.did
+++ b/candid/governance.did
@@ -4,6 +4,7 @@ type Action = variant {
   AddGenericNervousSystemFunction : NervousSystemFunction;
   RemoveGenericNervousSystemFunction : nat64;
   UpgradeSnsToNextVersion : record {};
+  TransferSnsTreasuryFunds : TransferSnsTreasuryFunds;
   UpgradeSnsControlledCanister : UpgradeSnsControlledCanister;
   Unspecified : record {};
   ManageSnsMetadata : ManageSnsMetadata;
@@ -36,6 +37,9 @@ type CanisterStatusResultV2 = record {
   module_hash : opt vec nat8;
 };
 type CanisterStatusType = variant { stopped; stopping; running };
+type ChangeAutoStakeMaturity = record {
+  requested_setting_for_auto_stake_maturity : bool;
+};
 type ClaimOrRefresh = record { by : opt By };
 type ClaimOrRefreshResponse = record { refreshed_neuron_id : opt NeuronId };
 type ClaimSwapNeuronsRequest = record {
@@ -54,6 +58,7 @@ type Command = variant {
   Configure : Configure;
   RegisterVote : RegisterVote;
   MakeProposal : Proposal;
+  StakeMaturity : StakeMaturity;
   RemoveNeuronPermissions : RemoveNeuronPermissions;
   AddNeuronPermissions : AddNeuronPermissions;
   MergeMaturity : MergeMaturity;
@@ -69,6 +74,7 @@ type Command_1 = variant {
   RegisterVote : record {};
   MakeProposal : GetProposal;
   RemoveNeuronPermission : record {};
+  StakeMaturity : StakeMaturityResponse;
   MergeMaturity : MergeMaturityResponse;
   Disburse : DisburseResponse;
   AddNeuronPermission : record {};
@@ -79,6 +85,7 @@ type Command_2 = variant {
   DisburseMaturity : DisburseMaturity;
   Configure : Configure;
   RegisterVote : RegisterVote;
+  SyncCommand : record {};
   MakeProposal : Proposal;
   ClaimOrRefreshNeuron : ClaimOrRefresh;
   RemoveNeuronPermissions : RemoveNeuronPermissions;
@@ -243,11 +250,13 @@ type NervousSystemParameters = record {
 };
 type Neuron = record {
   id : opt NeuronId;
+  staked_maturity_e8s_equivalent : opt nat64;
   permissions : vec NeuronPermission;
   maturity_e8s_equivalent : nat64;
   cached_neuron_stake_e8s : nat64;
   created_timestamp_seconds : nat64;
   source_nns_neuron_id : opt nat64;
+  auto_stake_maturity : opt bool;
   aging_since_timestamp_seconds : nat64;
   dissolve_state : opt DissolveState;
   voting_power_percentage_multiplier : nat64;
@@ -273,6 +282,7 @@ type NeuronPermission = record {
 };
 type NeuronPermissionList = record { permissions : vec int32 };
 type Operation = variant {
+  ChangeAutoStakeMaturity : ChangeAutoStakeMaturity;
   StopDissolving : record {};
   StartDissolving : record {};
   IncreaseDissolveDelay : IncreaseDissolveDelay;
@@ -322,12 +332,24 @@ type SetDissolveTimestamp = record { dissolve_timestamp_seconds : nat64 };
 type SetMode = record { mode : int32 };
 type Split = record { memo : nat64; amount_e8s : nat64 };
 type SplitResponse = record { created_neuron_id : opt NeuronId };
+type StakeMaturity = record { percentage_to_stake : opt nat32 };
+type StakeMaturityResponse = record {
+  maturity_e8s : nat64;
+  staked_maturity_e8s : nat64;
+};
 type Subaccount = record { subaccount : vec nat8 };
 type Tally = record {
   no : nat64;
   yes : nat64;
   total : nat64;
   timestamp_seconds : nat64;
+};
+type TransferSnsTreasuryFunds = record {
+  from_treasury : int32;
+  to_principal : opt principal;
+  to_subaccount : opt Subaccount;
+  memo : opt nat64;
+  amount_e8s : nat64;
 };
 type UpgradeInProgress = record {
   mark_failed_at_seconds : nat64;


### PR DESCRIPTION
The release experiment mostly worked, except that the Cargo.lock needed to be updated with the new version. The executables however are build with the --locked command. In this PR I rebuilt the main executable which upgraded Cargo.lock in the intended way.

I've also included the latest SNS Governance candid to support SnsTreasury proposals