### PR TITLE
no dapp_canister_id_list in sns-quill

### DIFF
--- a/tests/canister_ids.json
+++ b/tests/canister_ids.json
@@ -2,6 +2,5 @@
   "governance_canister_id": "rrkah-fqaaa-aaaaa-aaaaq-cai",
   "ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
   "root_canister_id": "r7inp-6aaaa-aaaaa-aaabq-cai",
-  "swap_canister_id": "rkp4c-7iaaa-aaaaa-aaaca-cai",
-  "dapp_canister_id_list": []
+  "swap_canister_id": "rkp4c-7iaaa-aaaaa-aaaca-cai"
 }


### PR DESCRIPTION
`dapp_canister_id_list` is not actually used in the code; so this PR drops this json entry from the code

why? now it feels like you should add the canister ID of a dapp you register with an SNS into the json file, but it's not really necessary because the corresponding json entry is not used at all